### PR TITLE
Enhancements to support use in configuration_client testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
+  gem 'pry'
   gem 'pry-nav'
   gem 'rspec', '2.14'
   gem 'guard-rspec'

--- a/lib/bunny_mock.rb
+++ b/lib/bunny_mock.rb
@@ -19,6 +19,7 @@ module BunnyMock
       nil
     end
 
+    # In the real Bunny gem, this method lives in Bunny::Session
     def create_channel
       BunnyMock::Channel.new
     end
@@ -31,26 +32,65 @@ module BunnyMock
       BunnyMock::Queue.new(*attrs)
     end
 
-    def exchange(*attrs)
-      BunnyMock::Exchange.new(*attrs)
+    def exchange(name, type, *attrs)
+      BunnyMock::Exchange.new(create_channel, type, name, attrs)
     end
+
+    def queue(name, *attrs)
+      BunnyMock::Queue.new(create_channel, name, *attrs)
+    end
+
   end # class Bunny
 
   class Channel
+    attr_accessor :exchanges, :queues
+
+    def initialize(*args)
+      @exchanges = {}
+      @queues = {}
+    end
+
+    # Declares a direct exchange or looks it up in the cache of previously
+    # declared exchanges.
     def direct(name)
-      BunnyMock::Exchange.new(name)
+      direct = exchanges[name]
+      return direct if direct
+      direct = BunnyMock::Exchange.new(self, :direct, name)
+      add_exchange(name, direct)
     end
 
+    # Declares a fanout exchange or looks it up in the cache of previously
+    # declared exchanges.
     def fanout(name)
-      BunnyMock::Exchange.new(name)
+      fanout = exchanges[name]
+      return fanout if fanout
+      add_exchange(name, BunnyMock::Exchange.new(self, :fanout, name))
     end
 
+    # Declares a topic exchange or looks it up in the cache of previously
+    # declared exchanges.
     def topic(name, attrs = {})
-      BunnyMock::Exchange.new(name, attrs)
+      topic = exchanges[name]
+      return topic if topic
+      add_exchange(name, BunnyMock::Exchange.new(self, :topic, name, attrs))
     end
+
+    # Declares a queue or looks it up in the per-channel cache.
 
     def queue(name, *args)
-      BunnyMock::Queue.new(*args)
+      queue = queues[name]
+      return queue if queue
+      add_queue(name, BunnyMock::Queue.new(self, name, *args))
+    end
+
+    private
+
+    def add_exchange(name, exchange)
+      @exchanges[name] = exchange
+    end
+
+    def add_queue(name, queue)
+      @queues[name] = queue
     end
   end
 
@@ -62,8 +102,10 @@ module BunnyMock
   end
 
   class Queue
-    attr_accessor :name, :attrs, :messages, :delivery_count
-    def initialize(name, attrs = {})
+    attr_accessor :channel, :name, :attrs, :messages, :delivery_count
+
+    def initialize(channel, name, attrs = {})
+      self.channel        = channel
       self.name           = name
       self.attrs          = attrs.dup
       self.messages       = []
@@ -116,8 +158,10 @@ module BunnyMock
   end # class Queue
 
   class Exchange
-    attr_accessor :name, :attrs, :queues
-    def initialize(name, attrs = {})
+    attr_accessor :channel, :type, :name, :attrs, :queues
+    def initialize(channel, type, name, attrs = {})
+      self.channel = channel
+      self.type = type
       self.name   = name
       self.attrs  = attrs.dup
       self.queues = []

--- a/lib/bunny_mock.rb
+++ b/lib/bunny_mock.rb
@@ -76,7 +76,6 @@ module BunnyMock
     end
 
     # Declares a queue or looks it up in the per-channel cache.
-
     def queue(name, *args)
       queue = queues[name]
       return queue if queue

--- a/lib/bunny_mock/version.rb
+++ b/lib/bunny_mock/version.rb
@@ -1,3 +1,3 @@
 module BunnyMock
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/spec/lib/bunny_mock_spec.rb
+++ b/spec/lib/bunny_mock_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe "BunnyMock Integration Tests", :integration => true do
   let(:bunny) {  BunnyMock::Bunny.new }


### PR DESCRIPTION
Allows BunnyMock to function as a full substitute for Bunny in configuration_client unit tests, thereby avoiding the overhead of having to connect to RabbitMQ.
- supports mocking of Channel, Queue, and Exchange caching
- brings the constructor interfaces of these classes in line with the Bunny API
- extends test coverage

specs pass!
