### PR TITLE
Update BunnyMock#new and Bunny#fanout

### DIFF
--- a/lib/bunny_mock.rb
+++ b/lib/bunny_mock.rb
@@ -1,8 +1,14 @@
 require "bunny_mock/version"
 
 module BunnyMock
+  extend self
+
+  def new(*args)
+    Bunny.new
+  end
 
   class Bunny
+
     def start
       :connected
     end
@@ -61,10 +67,10 @@ module BunnyMock
 
     # Declares a fanout exchange or looks it up in the cache of previously
     # declared exchanges.
-    def fanout(name)
+    def fanout(name, attrs = {})
       fanout = exchanges[name]
       return fanout if fanout
-      add_exchange(name, BunnyMock::Exchange.new(self, :fanout, name))
+      add_exchange(name, BunnyMock::Exchange.new(self, :fanout, name, attrs))
     end
 
     # Declares a topic exchange or looks it up in the cache of previously

--- a/lib/bunny_mock.rb
+++ b/lib/bunny_mock.rb
@@ -4,7 +4,7 @@ module BunnyMock
   extend self
 
   def new(*args)
-    Bunny.new
+    Bunny.new(*args)
   end
 
   class Bunny
@@ -25,6 +25,9 @@ module BunnyMock
       nil
     end
 
+    def initialize(*args)
+    end
+
     # In the real Bunny gem, this method lives in Bunny::Session
     def create_channel
       BunnyMock::Channel.new
@@ -34,16 +37,16 @@ module BunnyMock
       BunnyMock::Exchange.new(name, *args)
     end
 
-    def queue(*attrs)
-      BunnyMock::Queue.new(*attrs)
+    def queue(*args)
+      BunnyMock::Queue.new(*args)
     end
 
-    def exchange(name, type, *attrs)
-      BunnyMock::Exchange.new(create_channel, type, name, attrs)
+    def exchange(name, type, opts = {})
+      BunnyMock::Exchange.new(create_channel, type, name, opts)
     end
 
-    def queue(name, *attrs)
-      BunnyMock::Queue.new(create_channel, name, *attrs)
+    def queue(name, opts = {})
+      BunnyMock::Queue.new(create_channel, name, opts)
     end
 
   end # class Bunny
@@ -58,7 +61,7 @@ module BunnyMock
 
     # Declares a direct exchange or looks it up in the cache of previously
     # declared exchanges.
-    def direct(name)
+    def direct(name, opts)
       direct = exchanges[name]
       return direct if direct
       direct = BunnyMock::Exchange.new(self, :direct, name)
@@ -67,25 +70,25 @@ module BunnyMock
 
     # Declares a fanout exchange or looks it up in the cache of previously
     # declared exchanges.
-    def fanout(name, attrs = {})
+    def fanout(name, opts = {})
       fanout = exchanges[name]
       return fanout if fanout
-      add_exchange(name, BunnyMock::Exchange.new(self, :fanout, name, attrs))
+      add_exchange(name, BunnyMock::Exchange.new(self, :fanout, name, opts))
     end
 
     # Declares a topic exchange or looks it up in the cache of previously
     # declared exchanges.
-    def topic(name, attrs = {})
+    def topic(name, opts = {})
       topic = exchanges[name]
       return topic if topic
-      add_exchange(name, BunnyMock::Exchange.new(self, :topic, name, attrs))
+      add_exchange(name, BunnyMock::Exchange.new(self, :topic, name, opts))
     end
 
     # Declares a queue or looks it up in the per-channel cache.
-    def queue(name, *args)
+    def queue(name = '', opts = {})
       queue = queues[name]
       return queue if queue
-      add_queue(name, BunnyMock::Queue.new(self, name, *args))
+      add_queue(name, BunnyMock::Queue.new(self, name, opts))
     end
 
     private
@@ -107,12 +110,12 @@ module BunnyMock
   end
 
   class Queue
-    attr_accessor :channel, :name, :attrs, :messages, :delivery_count
+    attr_accessor :channel, :name, :options, :messages, :delivery_count
 
-    def initialize(channel, name, attrs = {})
+    def initialize(channel, name, opts = {})
       self.channel        = channel
       self.name           = name
-      self.attrs          = attrs.dup
+      self.options        = opts.dup
       self.messages       = []
       self.delivery_count = 0
     end
@@ -153,8 +156,8 @@ module BunnyMock
         key = method.to_sym
       end
 
-      if attrs.has_key? key
-        value = attrs[key]
+      if options.has_key? key
+        value = options[key]
         is_predicate ? !!value : value
       else
         super
@@ -163,13 +166,14 @@ module BunnyMock
   end # class Queue
 
   class Exchange
-    attr_accessor :channel, :type, :name, :attrs, :queues
-    def initialize(channel, type, name, attrs = {})
+    attr_accessor :channel, :type, :name, :options, :queues
+
+    def initialize(channel, type, name, opts = {})
       self.channel = channel
-      self.type = type
-      self.name   = name
-      self.attrs  = attrs.dup
-      self.queues = []
+      self.type    = type
+      self.name    = name
+      self.options = opts.dup
+      self.queues  = []
     end
 
     def publish(msg, msg_attrs = {})
@@ -183,15 +187,15 @@ module BunnyMock
     def method_missing(method, *args)
       method_name  = method.to_s
       is_predicate = false
-      if method_name =~ /^(.*)\?$/
+      if method_name =~ /^(.+)\?$/
         key           = $1.to_sym
         is_predicate = true
       else
         key = method.to_sym
       end
 
-      if attrs.has_key? key
-        value = attrs[key]
+      if options.has_key? key
+        value = options[key]
         is_predicate ? !!value : value
       else
         super

--- a/spec/lib/bunny_mock_spec.rb
+++ b/spec/lib/bunny_mock_spec.rb
@@ -64,6 +64,13 @@ end
 describe BunnyMock do
   let(:bunny) { BunnyMock::Bunny.new }
 
+  describe "#new" do
+    it "returns a new BunnyMock::Bunny instance" do
+      instance = BunnyMock.new('amqp://login:pass@server.com/vhost')
+      expect(instance.class).to eq(BunnyMock::Bunny)
+    end
+  end
+
   describe "#start" do
     it "connects" do
       expect(bunny.start).to eq(:connected)
@@ -98,7 +105,7 @@ describe BunnyMock do
     let(:channel) { bunny.create_channel }
 
     describe "#fanout" do
-      let(:fanout) { channel.fanout('fanout_test') }
+      let(:fanout) { channel.fanout('fanout_test', key_1: :value_1) }
 
       it "returns an exchange" do
         expect(fanout).to be_a(BunnyMock::Exchange)
@@ -110,6 +117,10 @@ describe BunnyMock do
 
       it "adds fanout exchange to the channel's exchange cache" do
         expect(fanout).to eq(channel.exchanges['fanout_test'])
+      end
+
+      it "passes along the optional options to the exchange" do
+        expect(fanout.options).to eq({key_1: :value_1})
       end
     end
 
@@ -188,9 +199,9 @@ describe BunnyMock::Queue do
     end
   end
 
-  describe "#attrs" do
+  describe "#options" do
     it "are consistent" do
-      expect(queue.attrs).to eq(queue_attrs)
+      expect(queue.options).to eq(queue_attrs)
     end
   end
 
@@ -338,7 +349,7 @@ describe BunnyMock::Exchange do
 
   describe "#attrs" do
     it "returns the attributes" do
-      expect(exchange.attrs).to eq(exchange_attrs)
+      expect(exchange.options).to eq(exchange_attrs)
     end
   end
 


### PR DESCRIPTION
- add optional options to `#fanout` to match Bunny's signature

I also added `BunnyMock.new`, it sort of mirrors `Bunny`'s way of doing it (a `self.new` method in the `Bunny` module).

Usecase:

I use this as a way to seamlessly override my Bunny depending on my envrionment without having to add logic to my code.

``` rb
# config/application.rb

Rails.application.configure do |config|
  # ...
  config.bunny_class = Bunny

# config/test.rb

Rails.application.configure do |config|
  # ...
  config.bunny_class = BunnyMock

# app/services/rabbitmq_service.rb

module RabbitmqService

  def client
    Rails.application.config.bunny_class.new('amqp://...')
  end

```

The rest of my code only access Bunny via `RabbitmqService.client` which will use Bunny in all environments except for test.
